### PR TITLE
Add drag-and-drop setup and persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,35 +17,36 @@
 
     <div class="mb-8 p-4 bg-white rounded-lg shadow-md max-w-md mx-auto">
         <h2 class="text-xl font-semibold mb-3 text-purple-700">Add New Task</h2>
-        <input type="text" id="newTaskInput" placeholder="Enter task description..." class="w-full p-2 border border-gray-300 rounded-md mb-3 focus:outline-none focus:ring-2 focus:ring-purple-500">
+        <input type="text" id="newTaskInput" placeholder="Enter task description..." class="w-full p-2 border border-gray-300 rounded-md mb-1 focus:outline-none focus:ring-2 focus:ring-purple-500">
+        <p id="validationError" class="text-red-600 mb-3 hidden"></p>
         <button id="addTaskBtn" class="w-full add-task-btn font-bold py-2 px-4 rounded-md">
             Add Task
         </button>
     </div>
 
     <div class="kanban-board">
-        <div id="todo" class="kanban-column p-4" ondragover="allowDrop(event)" ondrop="drop(event)" ondragleave="dragLeave(event)">
+        <div id="todo" class="kanban-column p-4">
             <h2 class="text-xl font-semibold mb-4 text-center text-purple-700 border-b-2 border-purple-200 pb-2">To Do 📝</h2>
             <div class="space-y-3 min-h-[50px]">
-                <div id="task-1" class="task-card p-3 shadow" draggable="true" ondragstart="drag(event)">
+                <div id="task-1" class="task-card p-3 shadow" draggable="true">
                     Plan the Grand Cheese Festival
                 </div>
             </div>
         </div>
 
-        <div id="inprogress" class="kanban-column p-4" ondragover="allowDrop(event)" ondrop="drop(event)" ondragleave="dragLeave(event)">
+        <div id="inprogress" class="kanban-column p-4">
             <h2 class="text-xl font-semibold mb-4 text-center text-yellow-600 border-b-2 border-yellow-200 pb-2">In Progress 🏃‍♀️💨</h2>
             <div class="space-y-3 min-h-[50px]">
-                 <div id="task-2" class="task-card p-3 shadow rose-gold-accent" draggable="true" ondragstart="drag(event)">
+                 <div id="task-2" class="task-card p-3 shadow rose-gold-accent" draggable="true">
                     Design new Royal Cheese Knight armor (with rose gold accents!)
                 </div>
             </div>
         </div>
 
-        <div id="done" class="kanban-column done-column p-4" ondragover="allowDrop(event)" ondrop="drop(event)" ondragleave="dragLeave(event)">
+        <div id="done" class="kanban-column done-column p-4">
             <h2 class="text-xl font-semibold mb-4 text-center text-green-600 border-b-2 border-green-200 pb-2">Done 🎉</h2>
             <div class="space-y-3 min-h-[50px]">
-                 <div id="task-3" class="task-card p-3 shadow" draggable="true" ondragstart="drag(event)">
+                 <div id="task-3" class="task-card p-3 shadow" draggable="true">
                     Taste test the new Parmesan variety
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- bind drag-and-drop events on page load
- switch to keydown event to add tasks with Enter
- show validation errors inline
- persist tasks across reloads with localStorage
- wrap all script code in an IIFE

## Testing
- `node -c script.js`
