### PR TITLE
Refactor Kanban board markup for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,40 +17,41 @@
 
     <div class="mb-8 p-4 bg-white rounded-lg shadow-md max-w-md mx-auto">
         <h2 class="text-xl font-semibold mb-3 text-purple-700">Add New Task</h2>
+        <label for="newTaskInput" class="block mb-1 font-medium">Task Description</label>
         <input type="text" id="newTaskInput" placeholder="Enter task description..." class="w-full p-2 border border-gray-300 rounded-md mb-3 focus:outline-none focus:ring-2 focus:ring-purple-500">
         <button id="addTaskBtn" class="w-full add-task-btn font-bold py-2 px-4 rounded-md">
             Add Task
         </button>
     </div>
 
-    <div class="kanban-board">
-        <div id="todo" class="kanban-column p-4" ondragover="allowDrop(event)" ondrop="drop(event)" ondragleave="dragLeave(event)">
+    <main class="kanban-board">
+        <section id="todo" class="kanban-column p-4">
             <h2 class="text-xl font-semibold mb-4 text-center text-purple-700 border-b-2 border-purple-200 pb-2">To Do 📝</h2>
-            <div class="space-y-3 min-h-[50px]">
-                <div id="task-1" class="task-card p-3 shadow" draggable="true" ondragstart="drag(event)">
+            <ul class="space-y-3 min-h-[50px]">
+                <li id="task-1" class="task-card p-3 shadow" draggable="true" role="listitem" aria-grabbed="false">
                     Plan the Grand Cheese Festival
-                </div>
-            </div>
-        </div>
+                </li>
+            </ul>
+        </section>
 
-        <div id="inprogress" class="kanban-column p-4" ondragover="allowDrop(event)" ondrop="drop(event)" ondragleave="dragLeave(event)">
-            <h2 class="text-xl font-semibold mb-4 text-center text-yellow-600 border-b-2 border-yellow-200 pb-2">In Progress 🏃‍♀️💨</h2>
-            <div class="space-y-3 min-h-[50px]">
-                 <div id="task-2" class="task-card p-3 shadow rose-gold-accent" draggable="true" ondragstart="drag(event)">
+        <section id="inprogress" class="kanban-column p-4">
+            <h2 class="text-xl font-semibold mb-4 text-center text-yellow-600 border-b-2 border-yellow-200 pb-2">In Progress 🏃</h2>
+            <ul class="space-y-3 min-h-[50px]">
+                 <li id="task-2" class="task-card p-3 shadow rose-gold-accent" draggable="true" role="listitem" aria-grabbed="false">
                     Design new Royal Cheese Knight armor (with rose gold accents!)
-                </div>
-            </div>
-        </div>
+                </li>
+            </ul>
+        </section>
 
-        <div id="done" class="kanban-column done-column p-4" ondragover="allowDrop(event)" ondrop="drop(event)" ondragleave="dragLeave(event)">
+        <section id="done" class="kanban-column done-column p-4">
             <h2 class="text-xl font-semibold mb-4 text-center text-green-600 border-b-2 border-green-200 pb-2">Done 🎉</h2>
-            <div class="space-y-3 min-h-[50px]">
-                 <div id="task-3" class="task-card p-3 shadow" draggable="true" ondragstart="drag(event)">
+            <ul class="space-y-3 min-h-[50px]">
+                 <li id="task-3" class="task-card p-3 shadow" draggable="true" role="listitem" aria-grabbed="false">
                     Taste test the new Parmesan variety
-                </div>
-            </div>
-        </div>
-    </div>
+                </li>
+            </ul>
+        </section>
+    </main>
 
 
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -3,7 +3,7 @@ let taskIdCounter = 4; // Start counter after initial tasks
 // --- Task Adding ---
 const addTaskBtn = document.getElementById('addTaskBtn');
 const newTaskInput = document.getElementById('newTaskInput');
-const todoColumn = document.getElementById('todo').querySelector('.space-y-3'); // Target the task container div
+const todoColumn = document.getElementById('todo').querySelector('.space-y-3'); // Task list container
 
 addTaskBtn.addEventListener('click', addTask);
 newTaskInput.addEventListener('keypress', function(e) {
@@ -19,10 +19,12 @@ function addTask() {
         return;
     }
 
-    const newTask = document.createElement('div');
+    const newTask = document.createElement('li');
     newTask.id = `task-${taskIdCounter++}`;
     newTask.className = 'task-card p-3 shadow';
     newTask.draggable = true;
+    newTask.setAttribute('role', 'listitem');
+    newTask.setAttribute('aria-grabbed', 'false');
     newTask.textContent = taskText;
     newTask.addEventListener('dragstart', drag);
 
@@ -44,6 +46,7 @@ function dragLeave(ev) {
 function drag(ev) {
     ev.dataTransfer.setData("text/plain", ev.target.id); // Store the id of the dragged element
     ev.target.classList.add('dragging'); // Add class for visual feedback during drag
+    ev.target.setAttribute('aria-grabbed', 'true');
     // Use setTimeout to allow the browser to render the 'dragging' state before hiding
     setTimeout(() => {
          // Optional: hide the original element smoothly if desired, but opacity handles it well
@@ -84,10 +87,11 @@ function drop(ev) {
 }
 
  // Add event listener to the document to clean up if drag ends outside a valid drop zone
- document.addEventListener('dragend', (ev) => {
+document.addEventListener('dragend', (ev) => {
     const draggedElement = document.querySelector('.dragging');
     if (draggedElement) {
         draggedElement.classList.remove('dragging');
+        draggedElement.setAttribute('aria-grabbed', 'false');
         // draggedElement.style.visibility = 'visible'; // Ensure visibility
     }
     // Remove any lingering drag-over styles
@@ -110,5 +114,14 @@ function triggerConfetti() {
 // Add dragstart listeners to initially loaded tasks
 document.querySelectorAll('.task-card').forEach(card => {
     card.addEventListener('dragstart', drag);
+    card.setAttribute('role', 'listitem');
+    card.setAttribute('aria-grabbed', 'false');
+});
+
+// Attach drag events to kanban columns
+document.querySelectorAll('.kanban-column').forEach(column => {
+    column.addEventListener('dragover', allowDrop);
+    column.addEventListener('drop', drop);
+    column.addEventListener('dragleave', dragLeave);
 });
 


### PR DESCRIPTION
## Summary
- wrap board in `<main>` and convert columns to `<section>`
- represent tasks using `<ul>`/`<li>`
- label new task input
- move drag handlers to JS and add ARIA attributes

## Testing
- `git status --short`